### PR TITLE
Modify annotations file format

### DIFF
--- a/WIPL/WIPL.comments
+++ b/WIPL/WIPL.comments
@@ -1,19 +1,19 @@
-0x108,	pre_comment , Entry point
-0x109 	,comment,	 Initialize some vars
-0x118 	,comment,	 0xc5
-0x120 	,comment,	 Stack at 0xf0 ???
-0x138 	,comment,	 Clearly corrupt here
-0x141,	pre_comment , Self-modifying code ahead!!!
-	,	 , The function at L_014b probes for DSK board at base address (AL << 16) + 0x40
-	,	 , and, if successful, sends an RTZ command.
-	,	 , These four stores patch the base address in the code below
-0x141 	,comment,	 14c
-0x143 	,comment,	 152
-0x14b 	,comment,	 Unit select
-0x14e 	,comment,	 Should be a READ command ?
-0x151 	,comment,	 Read command register ??? Some flaga ???
-0x154 	,comment,	 command_reg & 0x30
-0x158 	,comment,	 Should be 0x30. If not, we decrement AL and repeat the whole thing
-0x15c 	,comment,	 RTZ (recalibrate)
-0x162 	,comment,	 Wait for command_reg & 0x30 == 0x30 ( busy ?)
-0x185 	,comment,	 Corrupt here
+0x108,	pre_comment 	; Entry point
+0x109 ,	comment	; Initialize some vars
+0x118 ,	comment	; 0xc5
+0x120 ,	comment	; Stack at 0xf0 ???
+0x138 ,	comment	; Clearly corrupt here
+0x141,	pre_comment 	; Self-modifying code ahead!!!
+	 	; The function at L_014b probes for DSK board at base address (AL << 16) + 0x40
+	 	; and, if successful, sends an RTZ command.
+	 	; These four stores patch the base address in the code below
+0x141 ,	comment	; 14c
+0x143 ,	comment	; 152
+0x14b ,	comment	; Unit select
+0x14e ,	comment	; Should be a READ command ?
+0x151 ,	comment	; Read command register ??? Some flaga ???
+0x154 ,	comment	; command_reg & 0x30
+0x158 ,	comment	; Should be 0x30. If not, we decrement AL and repeat the whole thing
+0x15c ,	comment	; RTZ (recalibrate)
+0x162 ,	comment	; Wait for command_reg & 0x30 == 0x30 ( busy ?)
+0x185 ,	comment	; Corrupt here

--- a/extract_comments.py
+++ b/extract_comments.py
@@ -29,8 +29,8 @@ for line in lines:
         # We've found an address. Dump the accumulated pre_comments
         prefix = hex(address) + ",\tpre_comment"
         for text in pre_comment:
-            print(prefix, ",", text)
-            prefix = "\t,\t"
+            print(prefix, "\t;", text)
+            prefix = "\t"
         pre_comment = []
 
     if comment_start == -1:
@@ -41,14 +41,14 @@ for line in lines:
     text = line[comment_start + 1:].strip()
 
     if address is not None:
-        print(hex(address), "\t,comment,\t", text)
+        print(hex(address), ",\tcomment\t;", text)
         # This possibly starts a multi-line comment
         continuation = True
         continue;
 
     # An empty line with a sole comment. It can be a part of a multi-line comment
     if (continuation):
-        print("\t,\t,", text)
+        print("\t\t;", text)
     else:
         # This is part of a pre-comment. We don't know the address, so
         # accumulate these lines until we find one.


### PR DESCRIPTION
A comment is now on the end of line and separated by ';'. "comment" type is
optional, and an empty (or missing) field also stands for comment.

This provides for fewer typing and also ability to specify a comment on the same
line with data type annotation.

On request by Phire.